### PR TITLE
fixed a bug that prevents the bot from working in DM

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -36,7 +36,7 @@ class DiscordClient {
     this.rateLimit = {};
 
     this.client = new Client({ 
-      intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGE_REACTIONS] });
+      intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGE_REACTIONS], partials: ['CHANNEL'] });
   }
 
   loadCommands(dir=CLIENT_CONSTANTS.CMD_DIR) {

--- a/client/events/interactionCreate.js
+++ b/client/events/interactionCreate.js
@@ -1,3 +1,4 @@
+const { DMChannel } = require('discord.js');
 const generateEmbed = require('../methods/generateEmbed') 
 
 const INTERACTION_CONST = {
@@ -24,7 +25,7 @@ module.exports = {
       discord_id: interaction.user.id,
       discord_name: `${interaction.user.username}#${interaction.user.discriminator}`,
       guild_id: interaction.guildId,
-      guild_name: interaction.member.guild.name,
+      guild_name: interaction.channel instanceof DMChannel ? interaction.channel.recipient.username : interaction.member.guild.name,
       command: interaction.commandName,
       subcommand: interaction.options._subcommand,
       inputs: interaction.options._hoistedOptions


### PR DESCRIPTION
This PR makes it so that the logger check if the interaction is being issued from a DM or a Guild instead of assuming it's from a Guild like before.